### PR TITLE
Allow using faraday 0.12.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'concurrent-ruby-ext'
-gem 'faraday', '< 0.12.0' # https://github.com/lostisland/faraday/issues/679


### PR DESCRIPTION
Now faraday [0.12.0.1](https://rubygems.org/gems/faraday/versions/0.12.0.1) was released.
It solves checksum mismatch.