### PR TITLE
No thread mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Maximum number of worker threads.
 
 Default: number of logical cores
 
+#### `--no-use_threads`
+
+Do not use threads, process each message using raw pub/sub event
+callback.
+
+Default: use threads
+
 #### `--project_id=PROJECT_ID`, `--credentials=KEYFILE_PATH`
 
 Credentials of Google Cloud Platform. Please see [the document](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/AUTHENTICATION.md) for details.

--- a/exe/activejob-google_cloud_pubsub-worker
+++ b/exe/activejob-google_cloud_pubsub-worker
@@ -24,6 +24,10 @@ worker_args = parser.define_by_keywords(
   }
 )
 
+parser.on '--[no-]threads' do |o|
+  worker_args[:use_threads] = o
+end
+
 pubsub_args = parser.define_by_keywords(
   {},
   Google::Cloud::Pubsub.method(:new),


### PR DESCRIPTION
for better scalability control, it's better if the worker run on single thread

`--max-threads=N` cannot be used because the worker will consume all the messages, and reschedule then, running with --no-threads will block after each process, and not collecting the next message till ready to process it