### PR TITLE
Lazy initialization of pubsub

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ActiveJob::GoogleCloudPubsub, :use_pubsub_emulator do
   around :each do |example|
     $queue = Thread::Queue.new
 
-    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), &example
+    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), max_threads: 3, &example
   end
 
   example do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   private
 
   def run_pubsub_emulator(&block)
-    pipe = IO.popen('gcloud beta emulators pubsub start', err: %i(child out), pgroup: true)
+    pipe = IO.popen("#{gcloud_path} beta emulators pubsub start", err: %i(child out), pgroup: true)
 
     begin
       Timeout.timeout 10 do
@@ -41,7 +41,7 @@ RSpec.configure do |config|
         end
       end
 
-      host = `gcloud beta emulators pubsub env-init`.match(/^export PUBSUB_EMULATOR_HOST=(\S+)$/).captures.first
+      host = `#{gcloud_path} beta emulators pubsub env-init`.match(/^export PUBSUB_EMULATOR_HOST=(\S+)$/).captures.first
 
       block.call host
     ensure
@@ -52,5 +52,10 @@ RSpec.configure do |config|
         # already terminated
       end
     end
+  end
+
+  def gcloud_path
+    bin_path = File.join('google-cloud-sdk', 'bin')
+    Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,10 @@ RSpec.configure do |config|
   end
 
   def gcloud_path
-    bin_path = File.join('google-cloud-sdk', 'bin')
-    Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
+    @gcloud_path ||=
+      begin
+        bin_path = File.join('google-cloud-sdk', 'bin')
+        Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
+      end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
     begin
       Timeout.timeout 10 do
         pipe.each do |line|
-          break if line.include?('INFO: Server started')
+          break if line.include?('Server started, listening on')
 
           raise line if line.include?('Exception in thread')
         end


### PR DESCRIPTION
Don't instantiate Google::Cloud::Pubsub on initializing Adapter.
Because initializing adapter is called on executing task which loads jobs like `rake db:migrate`.
But Google::Cloud::Pubsub requires GCP project ID as environment variable, so it raises an ArgumentError on rake db:migrate like this:

```
Error occurred while loading application project_id is missing (ArgumentError)
    app/jobs/application_job.rb:3:in `<main>'
    app/jobs/async_task_job.rb:1:in `<main>'
    lib/tasks/erd.rake:3:in `block in <main>'
```

This PR avoids this error on development environment.
