### PR TITLE
Add on_error option to reject on error

### DIFF
--- a/spec/error_handling_spec.rb
+++ b/spec/error_handling_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+require 'json'
+require 'thread'
+require 'timeout'
+require 'active_support/inflector/inflections'
+
+RSpec.describe ActiveJob::GoogleCloudPubsub, :use_pubsub_emulator do
+  class ErrorJob < ActiveJob::Base
+    def perform(class_name)
+      raise class_name.constantize, "Test #{class_name}"
+    end
+  end
+
+  around :all do |example|
+    orig, ActiveJob::Base.logger = ActiveJob::Base.logger, nil
+    begin
+      example.run
+    ensure
+      ActiveJob::Base.logger = orig
+    end
+  end
+
+  shared_examples_for :error_handings do |on_error, expectation|
+    it do
+      args = {pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), on_error: on_error}
+      begin
+        worker = ActiveJob::GoogleCloudPubsub::Worker.new(**args)
+
+        worker.ensure_subscription
+
+        thread = Thread.new {
+          case on_error
+          when 'acknowledge'
+            expect_any_instance_of(Google::Cloud::Pubsub::ReceivedMessage).not_to receive(:reject!)
+            expect_any_instance_of(Google::Cloud::Pubsub::ReceivedMessage).to receive(:acknowledge!).and_call_original
+          when 'reject'
+            expect_any_instance_of(Google::Cloud::Pubsub::ReceivedMessage).to receive(:reject!).and_call_original
+            expect_any_instance_of(Google::Cloud::Pubsub::ReceivedMessage).not_to receive(:acknowledge!)
+          when 'none'
+            expect_any_instance_of(Google::Cloud::Pubsub::ReceivedMessage).not_to receive(:reject!)
+            expect_any_instance_of(Google::Cloud::Pubsub::ReceivedMessage).not_to receive(:acknowledge!)
+          end
+
+          worker.run
+        }
+
+        thread.abort_on_exception = true
+
+        ErrorJob.perform_later StandardError.name
+
+      ensure
+        thread.kill if thread
+      end
+    end
+  end
+
+  it_behaves_like :error_handings, 'acknowledge'
+  it_behaves_like :error_handings, 'reject'
+  it_behaves_like :error_handings, 'none'
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ActiveJob::GoogleCloudPubsub, :use_pubsub_emulator do
   around :each do |example|
     $queue = Thread::Queue.new
 
-    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), &example
+    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), max_threads: 3, &example
   end
 
   example do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   private
 
   def run_pubsub_emulator(&block)
-    pipe = IO.popen('gcloud beta emulators pubsub start', err: %i(child out), pgroup: true)
+    pipe = IO.popen("#{gcloud_path} beta emulators pubsub start", err: %i(child out), pgroup: true)
 
     begin
       Timeout.timeout 10 do
@@ -41,7 +41,7 @@ RSpec.configure do |config|
         end
       end
 
-      host = `gcloud beta emulators pubsub env-init`.match(/^export PUBSUB_EMULATOR_HOST=(\S+)$/).captures.first
+      host = `#{gcloud_path} beta emulators pubsub env-init`.match(/^export PUBSUB_EMULATOR_HOST=(\S+)$/).captures.first
 
       block.call host
     ensure
@@ -52,5 +52,10 @@ RSpec.configure do |config|
         # already terminated
       end
     end
+  end
+
+  def gcloud_path
+    bin_path = File.join('google-cloud-sdk', 'bin')
+    Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,10 @@ RSpec.configure do |config|
   end
 
   def gcloud_path
-    bin_path = File.join('google-cloud-sdk', 'bin')
-    Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
+    @gcloud_path ||=
+      begin
+        bin_path = File.join('google-cloud-sdk', 'bin')
+        Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
+      end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
     begin
       Timeout.timeout 10 do
         pipe.each do |line|
-          break if line.include?('INFO: Server started')
+          break if line.include?('Server started, listening on')
 
           raise line if line.include?('Exception in thread')
         end


### PR DESCRIPTION
Some systems expects to retry jobs on error. So this PR adds `on_error` option not to call `acknowledge` on error.

`on_error` expects `acknowledge` or `reject`. If `reject` is given, `activejob-google_cloud_pubsub` calls `reject!` ( [= delay! 0](https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb#L190-L192) ) on error. Then Cloud Pubsub delivers the message again.
