### PR TITLE
Fix spec to work on travis

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ActiveJob::GoogleCloudPubsub, :use_pubsub_emulator do
   around :each do |example|
     $queue = Thread::Queue.new
 
-    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), &example
+    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), max_threads: 3, &example
   end
 
   example do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   private
 
   def run_pubsub_emulator(&block)
-    pipe = IO.popen('gcloud beta emulators pubsub start', err: %i(child out), pgroup: true)
+    pipe = IO.popen("#{gcloud_path} beta emulators pubsub start", err: %i(child out), pgroup: true)
 
     begin
       Timeout.timeout 10 do
@@ -41,7 +41,7 @@ RSpec.configure do |config|
         end
       end
 
-      host = `gcloud beta emulators pubsub env-init`.match(/^export PUBSUB_EMULATOR_HOST=(\S+)$/).captures.first
+      host = `#{gcloud_path} beta emulators pubsub env-init`.match(/^export PUBSUB_EMULATOR_HOST=(\S+)$/).captures.first
 
       block.call host
     ensure
@@ -52,5 +52,10 @@ RSpec.configure do |config|
         # already terminated
       end
     end
+  end
+
+  def gcloud_path
+    bin_path = File.join('google-cloud-sdk', 'bin')
+    Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,10 @@ RSpec.configure do |config|
   end
 
   def gcloud_path
-    bin_path = File.join('google-cloud-sdk', 'bin')
-    Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
+    @gcloud_path ||=
+      begin
+        bin_path = File.join('google-cloud-sdk', 'bin')
+        Dir.exist?(bin_path) ? File.join(bin_path, 'gcloud') : 'gcloud'
+      end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
     begin
       Timeout.timeout 10 do
         pipe.each do |line|
-          break if line.include?('INFO: Server started')
+          break if line.include?('Server started, listening on')
 
           raise line if line.include?('Exception in thread')
         end


### PR DESCRIPTION
@ursm I fixed spec to pass on travis-ci.

- Specify path to gcloud command if `google-cloud-sdk` exists to avoid the following error:
    ```
    ERROR: (gcloud.beta.emulators.pubsub.env-init) You cannot perform this action because this Cloud SDK installation is managed by an external package manager.
    Please consider using a separate installation of the Cloud SDK created through the default mechanism described at: https://cloud.google.com/sdk/
    ```
- Specify max_threads to use 3 threads even if the number of processors is less than 3 (like travis) to avoid the following error:
    ```
    Message(3) was rescheduled after 10 seconds because the thread pool is full.
    ```
- Modify expected message to know if pubsub emulator starts.
    Because `INFO` depends on language of the environment.
    For example, `情報` is used in Japanese language environment instead.
