### PR TITLE
Fix compatibility issue since gem version 0.34.0 google google-cloud-pubsub

### DIFF
--- a/lib/activejob-google_cloud_pubsub/pubsub_extension.rb
+++ b/lib/activejob-google_cloud_pubsub/pubsub_extension.rb
@@ -5,7 +5,7 @@ module ActiveJob
     module PubsubExtension
       refine Google::Cloud::Pubsub::Project do
         def topic_for(queue_name)
-          name = "activejob-queue-#{queue_name}"
+          name = "projects/#{project_id}/topics/activejob-queue-#{queue_name}"
 
           topic(name) || create_topic(name)
         end

--- a/lib/activejob-google_cloud_pubsub/version.rb
+++ b/lib/activejob-google_cloud_pubsub/version.rb
@@ -1,5 +1,5 @@
 module ActiveJob
   module GoogleCloudPubsub
-    VERSION = '0.7.1'
+    VERSION = '0.7.2'
   end
 end

--- a/lib/activejob-google_cloud_pubsub/worker.rb
+++ b/lib/activejob-google_cloud_pubsub/worker.rb
@@ -35,7 +35,7 @@ module ActiveJob
             }
           rescue Concurrent::RejectedExecutionError
             Concurrent::Promise.execute(args: message) {|msg|
-              msg.delay! 10.seconds.to_i
+              msg.modify_ack_deadline! 10.seconds.to_i
 
               @logger&.info "Message(#{msg.message_id}) was rescheduled after 10 seconds because the thread pool is full."
             }.rescue {|e|
@@ -61,7 +61,7 @@ module ActiveJob
         else
           deadline = [message.remaining_time_to_schedule, MAX_DEADLINE.to_i].min
 
-          message.delay! deadline
+          message.modify_ack_deadline! deadline
 
           @logger&.info "Message(#{message.message_id}) was scheduled at #{message.scheduled_at} so it was rescheduled after #{deadline} seconds."
         end
@@ -75,7 +75,7 @@ module ActiveJob
         }
 
         delay_timer = Concurrent::TimerTask.execute(timer_opts) {
-          message.delay! MAX_DEADLINE.to_i
+          message.modify_ack_deadline! MAX_DEADLINE.to_i
         }
 
         begin
@@ -98,7 +98,7 @@ module ActiveJob
             @logger&.info "Message(#{message.message_id}) was acknowledged."
           else
             # terminated from outside
-            message.delay! 0
+            message.modify_ack_deadline! 0
           end
         end
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ActiveJob::GoogleCloudPubsub, :use_pubsub_emulator do
   around :each do |example|
     $queue = Thread::Queue.new
 
-    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), &example
+    run_worker pubsub: Google::Cloud::Pubsub.new(emulator_host: @pubsub_emulator_host, project_id: 'activejob-test'), max_threads: 3, &example
   end
 
   example do


### PR DESCRIPTION
Since the 1st of February in 2019, gem google-cloud-pubsub has been updated (0.34.0 version) and it brokes compatibility with this current gem.

Extract from google-cloud-pubsub's changelog, 0.34.0 version :
* Remove the #delay alias for modify_ack_deadline.
  * Users should use the modify_ack_deadline and modify_ack_deadline!
    methods directly instead.



